### PR TITLE
Adding simple KV feature to the application configuration, saved to consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Push all local consul state to remote consul cluster.
 
 Push all `service{}` stanza to remote Consul cluster
 
+#### `consul-push-kv`
+
+Push all `kv{}` stanza to remote Consul cluster
+
 ### vault commands
 
 #### `vault-create-token`
@@ -166,7 +170,7 @@ The following is a sample workflow that may be used for organizations with Consu
 
 The directory structure is laid out like described below:
 
-- `/${env}/apps/${app}.hcl` (encrypted) Vault secrets for an application in a specific environment.
+- `/${env}/apps/${app}.hcl` (encrypted) Vault secrets or (cleartext) Consul KeyValue for an application in a specific environment.
 - `/${env}/auth/${name}.hcl` (encrypted) [Vault auth backends](https://www.vaultproject.io/docs/auth/index.html) for an specific environment `${env}`.
 - `/${env}/consul_services/${type}.hcl` (cleartext) List of static Consul services that should be made available in an specific environment `${env}`.
 - `/${env}/databases/${name}/_mount.hcl` (encrypted) [Vault secret backend](https://www.vaultproject.io/docs/secrets/index.html) configuration for an specific mount `${name}` in `${env}`.
@@ -203,6 +207,22 @@ environment "production" {
     # an sample secret, will be written to secrets/api-admin/API_URL in Vault
     secret "API_URL" {
       value = "http://localhost:8181"
+    }
+  }
+}
+```
+
+### Consul app KV
+
+```hcl
+environment "production" {
+
+  # application name must match the file name
+  application "api-admin" {
+
+    # cleartext configuration for the application, will be written to /api-admin/threads
+    kv "threads" {
+      value = "10"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -216,13 +216,21 @@ environment "production" {
 
 ```hcl
 environment "production" {
+  kv "name" "production" {}
 
   # application name must match the file name
   application "api-admin" {
 
-    # cleartext configuration for the application, will be written to /api-admin/threads
-    kv "threads" {
-      value = "10"
+    # cleartext shorthand configuration for the application, will be written to /api-admin/threads
+    kv "threads" "10" {}
+
+    # cleartext configuration for the application, will be written to /api-admin/config
+    kv "config" {
+      value = <<EOF
+Some
+file
+value!
+EOF
     }
   }
 }

--- a/command/consul/kv_push.go
+++ b/command/consul/kv_push.go
@@ -1,0 +1,43 @@
+package consul
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/consul/api"
+	"github.com/seatgeek/hashi-helper/config"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+// KVPush ...
+func KVPush(c *cli.Context) error {
+	config, err := config.NewConfigFromCLI(c)
+	if err != nil {
+		return err
+	}
+
+	return KVPushWithConfig(c, config)
+}
+
+// KVPushWithConfig ...
+func KVPushWithConfig(c *cli.Context, config *config.Config) error {
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	kvService := client.KV()
+
+	for _, kv := range config.ConsulKVs {
+		log.Infof("Saving consul KV %s", kv.Key)
+
+		consulKV := kv.ToConsulKV()
+
+		meta, err := kvService.Put(consulKV, &api.WriteOptions{})
+		if err != nil {
+			return err
+		}
+
+		log.Infof("  Saved KV in %s", meta.RequestTime.String())
+	}
+
+	return nil
+}

--- a/command/consul/push_all.go
+++ b/command/consul/push_all.go
@@ -21,5 +21,9 @@ func PushAllWithConfig(cli *cli.Context, config *cfg.Config) error {
 		return err
 	}
 
+	if err := KVPushWithConfig(cli, config); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/config/parse_application.go
+++ b/config/parse_application.go
@@ -45,7 +45,7 @@ func (c *Config) processApplications(applicationsAST *ast.ObjectList, environmen
 			return err
 		}
 
-		log.Debug("    Scanning for KV")
+		log.Debug("    Scanning for consul KV")
 		if err := c.processConsulKV(x.Filter("kv"), environment, application); err != nil {
 			return err
 		}

--- a/config/parse_application.go
+++ b/config/parse_application.go
@@ -26,7 +26,7 @@ func (c *Config) processApplications(applicationsAST *ast.ObjectList, environmen
 
 		// Check for valid keys inside an application stanza
 		x := appAST.Val.(*ast.ObjectType).List
-		valid := []string{"secret", "policy"}
+		valid := []string{"secret", "policy", "kv"}
 		if err := checkHCLKeys(x, valid); err != nil {
 			return err
 		}
@@ -42,6 +42,11 @@ func (c *Config) processApplications(applicationsAST *ast.ObjectList, environmen
 
 		log.Debug("    Scanning for policy")
 		if err := c.processVaultPolicies(x.Filter("policy"), environment, application); err != nil {
+			return err
+		}
+
+		log.Debug("    Scanning for KV")
+		if err := c.processConsulKV(x.Filter("kv"), environment, application); err != nil {
 			return err
 		}
 

--- a/config/parse_consul_kv.go
+++ b/config/parse_consul_kv.go
@@ -19,15 +19,24 @@ func (c *Config) processConsulKV(list *ast.ObjectList, env *Environment, app *Ap
 			return err
 		}
 
-		if len(kvAST.Keys) != 1 {
+		if len(kvAST.Keys) == 0 {
 			return fmt.Errorf("Missing kv path in line %+v", kvAST.Keys[0].Pos())
 		}
 
 		key := kvAST.Keys[0].Token.Value().(string)
 
-		value, err := getKeyString("value", x)
-		if err != nil {
-			return err
+		var value string
+
+		if len(kvAST.Keys) == 1 {
+			var err error
+			value, err = getKeyString("value", x)
+			if err != nil {
+				return err
+			}
+		} else if len(kvAST.Keys) == 2 {
+			value = kvAST.Keys[1].Token.Value().(string)
+		} else {
+			return fmt.Errorf("Invalid number of parameter (%+v) on kv in line %+v", len(kvAST.Keys), kvAST.Keys[0].Pos())
 		}
 
 		kv := &ConsulKV{

--- a/config/parse_consul_kv.go
+++ b/config/parse_consul_kv.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+)
+
+func (c *Config) processConsulKV(list *ast.ObjectList, env *Environment, app *Application) error {
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	for _, kvAST := range list.Items {
+		x := kvAST.Val.(*ast.ObjectType).List
+
+		valid := []string{"value"}
+		if err := checkHCLKeys(x, valid); err != nil {
+			return err
+		}
+
+		if len(kvAST.Keys) != 1 {
+			return fmt.Errorf("Missing kv path in line %+v", kvAST.Keys[0].Pos())
+		}
+
+		key := kvAST.Keys[0].Token.Value().(string)
+
+		value, err := getKeyString("value", x)
+		if err != nil {
+			return err
+		}
+
+		kv := &ConsulKV{
+			Application: app,
+			Environment: env,
+			Key:         key,
+			Value:       []byte(value),
+		}
+
+		c.ConsulKVs.Add(kv)
+	}
+
+	return nil
+}

--- a/config/parse_environment.go
+++ b/config/parse_environment.go
@@ -40,7 +40,7 @@ func (c *Config) processEnvironments(list *ast.ObjectList) error {
 
 		// check for valid keys inside an environment stanza
 		x := envAST.Val.(*ast.ObjectType).List
-		valid := []string{"application", "auth", "policy", "mount", "secret", "service"}
+		valid := []string{"application", "auth", "policy", "mount", "secret", "service", "kv"}
 		if err := checkHCLKeys(x, valid); err != nil {
 			return err
 		}
@@ -74,6 +74,11 @@ func (c *Config) processEnvironments(list *ast.ObjectList) error {
 
 		log.Debug("  Scanning for consul services")
 		if err := c.processConsulServices(x.Filter("service"), env); err != nil {
+			return err
+		}
+
+		log.Debug("  Scanning for consul KV")
+		if err := c.processConsulKV(x.Filter("kv"), env, nil); err != nil {
 			return err
 		}
 

--- a/config/type_config.go
+++ b/config/type_config.go
@@ -23,6 +23,7 @@ type Config struct {
 	VaultSecrets   VaultSecrets
 	VaultAuths     VaultAuths
 	ConsulServices ConsulServices
+	ConsulKVs      ConsulKVs
 }
 
 // NewConfig will create a new Config struct based on a directory

--- a/config/type_consul_kv.go
+++ b/config/type_consul_kv.go
@@ -1,0 +1,36 @@
+package config
+
+import "github.com/hashicorp/consul/api"
+import "fmt"
+
+// ConsulKV ...
+type ConsulKV struct {
+	Application *Application
+	Environment *Environment
+	Key         string
+	Value       []byte
+}
+
+// ToConsulKV ...
+func (c *ConsulKV) ToConsulKV() *api.KVPair {
+	return &api.KVPair{
+		Key:   c.toPath(),
+		Value: c.Value,
+	}
+}
+
+func (c *ConsulKV) toPath() string {
+	if c.Application != nil {
+		return fmt.Sprintf("%v/%v", c.Application.Name, c.Key)
+	}
+	return c.Key
+}
+
+// ConsulKV struct
+//
+type ConsulKVs []*ConsulKV
+
+// Add ...
+func (cs *ConsulKVs) Add(kv *ConsulKV) {
+	*cs = append(*cs, kv)
+}

--- a/main.go
+++ b/main.go
@@ -232,6 +232,13 @@ func main() {
 				return consulCommand.ServicesPush(c)
 			},
 		},
+		{
+			Name:  "consul-push-kv",
+			Usage: "Push all known consul kv to remote Consul cluster",
+			Action: func(c *cli.Context) error {
+				return consulCommand.KVPush(c)
+			},
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		// convert the human passed log level into logrus levels


### PR DESCRIPTION
Since we might be using this tool to build our pipeline to push both Consul and Vault information, the tool was lacking simple KV feature.

We added the kv keyword at the application level, to be able to push application config for each application independently.