### PR TITLE
Enable encrypted HCL files via Keybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
-# This fork of `hashi-helper`
+# hashi-helper
 
-This fork extends [seatgeek's `hashi-helper`](https://github.com/seatgeek/hashi-helper) by decrypting and parsing configuration files which have been encrypted (on disk) via [Keybase](https://keybase.io/).
+`hashi-helper` is a tool meant to enable Disaster Recovery and Configuration Management for Consul and Vault clusters, by exposing configuration via a simple to use and share `hcl` format.
 
-## New features
-
-`hashi-helper` inspects each ingested HCL file for `-----BEGIN PGP MESSAGE-----`  and attempts to decrypt it (in memory only) with Keybase if possible. If decryption succeeds, it pushes the cleartext payload to Vault (or Consul) via the existing method. `hashi-helper` does not place any unencrypted content on disk. This workflow assumes Keybase was employed (separately) to encrypt the HCL files on disk.
-
-## To do
-
-- Enable generic PGP-encrypted file editing (extend `vault-profile-edit`).
-- Add optional warning for unencrypted HCL files.
-
-***
-
-# hashi-helper (original documentation)
-
-`hashi-helper` is a tool meant to enable Disaster Recovery and Configuration Management for Consul and Vault clusters, by exposing configuration via a simple to use and share hcl format.
+`hashi-helper` inspects each ingested `hcl` file for `-----BEGIN PGP MESSAGE-----`  and attempts to decrypt it (in memory only) with [Keybase](https://keybase.io/) if possible. If decryption succeeds, it pushes the cleartext payload to Vault (or Consul). `hashi-helper` does not place any unencrypted content on disk. This workflow assumes Keybase was employed (separately) to encrypt the `hcl` files on disk. Optionally, `hashi-helper` will warn if it encounters an _unencrypted_ `hcl` file.  
 
 ## Requirements
 
@@ -60,6 +47,7 @@ hashi-helper [--global-flags] command [--command-flags]
 - `--config-file` / `CONFIG_FILE`: A single `hcl` configuration file to parse instead of a directory (optional; default: `<empty>`)
 - `--environment` / `ENVIRONMENT`: The environment to process for (optional; default: `all`)
 - `--application` / `APPLICATION`: The application to process for (optional; default: `all`)
+- `--warn-unencrypted` / `WARN_UNENCRYPTED`: Issue a warning if unencrypted HCL files are discovered.
 
 ### Global Commands
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ vault_profile_name_2:
 ...
 encrypted-file-config:
   keybase-team-name: < your keybase team name >
-  editor: < your favorite editor > # defaults to $EDITOR, then pico
+  editor: < your favorite editor > # defaults to $EDITOR, this, then pico
 ...
 ```
-Note that when used with the `--use-keybase-team` global flag below, `keybase-team-name` will be used to create a Keybase PGP identity member list, and each members' PGP identity will be used when re-encrypting and re-signing files.
-
+Note that if `--no-keybase-team` global flag is set, `keybase-team-name` will be ignored and only the local Keybase PGP profile will be used.
 
 ## Usage
 
@@ -68,7 +67,7 @@ hashi-helper [--global-flags] command [--command-flags]
 - `--environment` / `ENVIRONMENT`: The environment to process for (optional; default: `all`)
 - `--application` / `APPLICATION`: The application to process for (optional; default: `all`)
 - `--warn-unencrypted` / `WARN_UNENCRYPTED`: Issue a warning if unencrypted HCL files are discovered.
-- `--use-keybase-team` / `USE_KEYBASE_TEAM`: Use the keybase team name in `.hashi-helper-config.yml.pgp` to re-sign encrypted files post-edit.
+- `--no-keybase-team` / `NO_KEYBASE_TEAM`: Ignore the Keybase team name in `.hashi-helper-config.yml.pgp` (if set).
 
 ### Global Commands
 
@@ -78,9 +77,9 @@ Push all Consul and Vault data to remote servers (same as running `vault-push-al
 
 #### `edit-file < file name >`
 
-Edit any Keybase PGP-encrypted `hcl.pgp` configuration file `< file name >` with editor specified in `.hashi-helper-config.yml.pgp` `encrypted-hcl-config:  editor:` block, or `$EDITOR` environment variable, or `pico` (in that order). File is decrypted, the external editor invoked, and re-encrypted post-edit. All temporary files are deleted.
+Edit any Keybase PGP-encrypted `hcl.pgp` configuration file `< file name >` with editor specified in the `$EDITOR` environment variable,, or`.hashi-helper-config.yml.pgp` `encrypted-hcl-config:  editor:` block, or `pico` (in that order). File is decrypted, the external editor invoked, and re-encrypted post-edit. All temporary files are deleted.
 
-This may be used to edit the `hashi-helper` config file itself (`~/.hashi-helper-config.yml.pgp` / `$HASHIHELPER_CONFIG_FILE`) and may optionally be paired with `--use-keybase-team`. When used to edit the `hashi-helper` config file, this functionality is equivalent to `vault-profile-edit`.
+This may be used to edit the `hashi-helper` config file itself (`~/.hashi-helper-config.yml.pgp` / `$HASHIHELPER_CONFIG_FILE`) and may optionally be paired with `--no-keybase-team`. When used to edit the `hashi-helper` config file, this functionality is equivalent to `vault-profile-edit`.
 
 If `< file name >` does not exist, a new file will be created.
 
@@ -176,6 +175,10 @@ Write Vault `policy {}` stanza found in `conf.d/` to remote vault server
 
 Write local secrets to remote Vault instance
 
+#### `vault-delete-secrets`
+
+Delete remote secrets from Vault. Leaves local secrets unchanged. Optionally suppress confirmations of each delete with `--skip-confirm`.
+
 #### `vault-unseal-keybase`
 
 Unseal Vault using the raw unseal key from [keybase / gpg init/rekey](https://www.vaultproject.io/docs/concepts/pgp-gpg-keybase.html) .
@@ -202,7 +205,7 @@ The directory structure is laid out like described below:
 - `/${env}/databases/${name}/_mount.hcl` (unencrypted) / `/${env}/databases/${name}/_mount.hcl.pgp` (encrypted) [Vault secret backend](https://www.vaultproject.io/docs/secrets/index.html) configuration for an specific mount `${name}` in `${env}`.
 - `/${env}/databases/${name}/*.hcl` (unencrypted) / `/${env}/databases/${name}/*.hcl.pgp` (encrypted) [Vault secret backend](https://www.vaultproject.io/docs/secrets/index.html) configuration for an specific Vault role belonging to mount `${name}` in `${env}`.
 
-*Note*: `hashi-helper` does not rely on the file extension to determine if a file is encrypted. It inspects the contents of the file. 
+*Note*: `hashi-helper` does not rely on the file extension to determine if a file is encrypted. It inspects the contents of the file.
 
 ### Configuration Examples
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# hashi-helper
+# This fork of `hashi-helper`
+
+This fork extends [seatgeek's `hashi-helper`](https://github.com/seatgeek/hashi-helper) by decrypting and parsing configuration files which have been encrypted (on disk) via [Keybase](https://keybase.io/).
+
+## New features
+
+`hashi-helper` inspects each ingested HCL file for `-----BEGIN PGP MESSAGE-----`  and attempts to decrypt it (in memory only) with Keybase if possible. If decryption succeeds, it pushes the cleartext payload to Vault (or Consul) via the existing method. `hashi-helper` does not place any unencrypted content on disk. This workflow assumes Keybase was employed (separately) to encrypt the HCL files on disk.
+
+## To do
+
+- Enable generic PGP-encrypted file editing (extend `vault-profile-edit`).
+- Add optional warning for unencrypted HCL files.
+
+***
+
+# hashi-helper (original documentation)
 
 `hashi-helper` is a tool meant to enable Disaster Recovery and Configuration Management for Consul and Vault clusters, by exposing configuration via a simple to use and share hcl format.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ hashi-helper [--global-flags] command [--command-flags]
 - `--environment` / `ENVIRONMENT`: The environment to process for (optional; default: `all`)
 - `--application` / `APPLICATION`: The application to process for (optional; default: `all`)
 - `--warn-unencrypted` / `WARN_UNENCRYPTED`: Issue a warning if unencrypted HCL files are discovered.
-- `--use-keybase-team` / `USE_KEYBASE_TEAM`: Use the keybase team name in `.hashi-helper-config.pgp` to re-sign encrypted hcl files post-edit. **Only** used with global command `edit-encrypted-file`. Note this does not affect nor apply to editing `.hashi-helper-config.pgp` itself.
+- `--use-keybase-team` / `USE_KEYBASE_TEAM`: Use the keybase team name in `.hashi-helper-config.pgp` to re-sign encrypted files post-edit.
 
 ### Global Commands
 
@@ -82,7 +82,7 @@ Edit any Keybase PGP-encrypted `hcl` configuration file `< file name >` with edi
 
 This may be used to edit the `hashi-helper` config file itself (`~/.hashi-helper-config.pgp` / `$HASHIHELPER_CONFIG_FILE`) and may optionally be paired with `--use-keybase-team`. When used to edit the `hashi-helper` config file, this functionality is equivalent to `vault-profile-edit`.
 
-If `< file name >` does not exist, a new file will be created. 
+If `< file name >` does not exist, a new file will be created.
 
 ### Consul
 

--- a/command/command.go
+++ b/command/command.go
@@ -1,0 +1,4 @@
+package command
+
+// UseKeybaseTeam ...
+var UseKeybaseTeam bool

--- a/command/command.go
+++ b/command/command.go
@@ -1,4 +1,4 @@
 package command
 
-// UseKeybaseTeam ...
-var UseKeybaseTeam bool
+// NoKeybaseTeam ...
+var NoKeybaseTeam bool

--- a/command/edit.go
+++ b/command/edit.go
@@ -45,21 +45,20 @@ func EditEncryptedFile(c *cli.Context) error {
 		return fmt.Errorf("No encrypted-file-config block found in config file.\n")
 	}
 	// editor
-	editor := preference.Editor
+	editor := os.Getenv("EDITOR")
 	if editor == "" {
-		editor = os.Getenv("EDITOR")
+		editor = preference.Editor
 	}
 	if editor == "" {
 		editor = "pico"
 	}
 	// keybase team
-	var keybaseTeam string = ""
-	if UseKeybaseTeam == true {
-		keybaseTeam = preference.KeybaseTeam
-		if keybaseTeam == "" {
-			UseKeybaseTeam = false
-			log.Warnf("--use-keybase-team set to true but no Keybase Team name found in config file. Not using Keybase Team.\n")
-		}
+	var keybaseTeam string = preference.KeybaseTeam
+	if keybaseTeam == "" && NoKeybaseTeam == false {
+		log.Warnf("No Keybase Team found in config (and --no-keybase-team is unset). Not using Keybase Team.\n")
+	}
+	if NoKeybaseTeam == true {
+		keybaseTeam = ""
 	}
 
 	// create the temporary file
@@ -105,7 +104,7 @@ func EditEncryptedFile(c *cli.Context) error {
 		                         "--i", tempFile.Name(),
 	                           "--o", filePath)
 	log.Infof("Re-encrypting updated %s.\n", filePath)
-	if UseKeybaseTeam == true {
+	if NoKeybaseTeam == false { // I know, a double negative. Sue me.
 		cmd := "keybase team list-members " + keybaseTeam + " | awk '{print $3}' | tr '\\n' ' ' | xargs | tr -d '\\n'"
     memberListCmd := exec.Command("bash", "-c", cmd)
 		var stdout bytes.Buffer

--- a/command/edit.go
+++ b/command/edit.go
@@ -1,0 +1,137 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	cli "gopkg.in/urfave/cli.v1"
+	log "github.com/Sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+	vault "github.com/seatgeek/hashi-helper/command/vault"
+)
+
+type preferences map[string]preference
+type preference struct {
+	KeybaseTeam  string `yaml:"keybase-team-name"`
+	Editor string `yaml:"editor"`
+}
+
+// EditEncryptedFile ...
+func EditEncryptedFile(c *cli.Context) error {
+
+	// identify the target file
+	if !c.Args().Present() {
+		return fmt.Errorf("Please provide a path and file name.")
+	}
+	filePath := c.Args().First()
+	if filePath == "" {
+		return fmt.Errorf("Empty path and file name.")
+	}
+
+	// get the preferences, define the editor and keybase team
+	var preferences preferences
+	configFile, err := vault.GetProfileConfig()
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(configFile, &preferences); err != nil {
+		return err
+	}
+	preference, ok := preferences["encrypted-file-config"]
+	if !ok {
+		return fmt.Errorf("No encrypted-file-config block found in config file.\n")
+	}
+	// editor
+	editor := preference.Editor
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		editor = "pico"
+	}
+	// keybase team
+	var keybaseTeam string = ""
+	if UseKeybaseTeam == true {
+		keybaseTeam = preference.KeybaseTeam
+		if keybaseTeam == "" {
+			UseKeybaseTeam = false
+			log.Warnf("--use-keybase-team set to true but no Keybase Team name found in config file. Not using Keybase Team.\n")
+		}
+	}
+
+	// create the temporary file
+	tempFile, err := ioutil.TempFile("", "encrypted-hcl")
+	if err != nil {
+		return err
+	}
+
+	// if the target file exist, decrypt the contents and copy into the temp file
+	if _, err := os.Stat(filePath); err == nil {
+
+		cmd := exec.Command("keybase", "pgp", "decrypt", "--infile", filePath)
+
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		log.Infof("Starting keybase decrypt of %s\n", filePath)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("Failed to run keybase gpg decrypt: %s - %s",
+				                    err, stderr.String())
+		}
+
+		tempFile.Write(stdout.Bytes())
+	}
+
+	// edit the temp file
+	editCmd := exec.Command(editor, tempFile.Name())
+	editCmd.Stdin  = os.Stdin
+	editCmd.Stdout = os.Stdout
+	editCmd.Stderr = os.Stderr
+	editErr := editCmd.Run()
+	if editErr != nil {
+		return editErr
+	}
+
+	// editing complete. replace the original file with the temp file and re-encrypt
+	// optionally with keybase team members
+	encryptCmd := exec.Command("keybase", "pgp", "encrypt",
+		                         "--i", tempFile.Name(),
+	                           "--o", filePath)
+	log.Infof("Re-encrypting updated %s.\n", filePath)
+	if UseKeybaseTeam == true {
+		cmd := "keybase team list-members " + keybaseTeam + " | awk '{print $3}' | tr '\\n' ' ' | xargs | tr -d '\\n'"
+    memberListCmd := exec.Command("bash", "-c", cmd)
+		var stdout bytes.Buffer
+		memberListCmd.Stdout = &stdout
+
+		var stderr bytes.Buffer
+		memberListCmd.Stderr = &stderr
+
+		memberListErr := memberListCmd.Run()
+		if memberListErr != nil {
+			return memberListErr
+		}
+
+		memberList := stdout.String()
+		cmd = "keybase pgp encrypt " + memberList + " --i " + tempFile.Name() + " --o " + filePath
+		encryptCmd = exec.Command("bash", "-c", cmd)
+	  log.Infof("Using Keybase team \"%s\" with members \"%s\".\n", keybaseTeam, memberList)
+	}
+	encryptErr := encryptCmd.Run()
+	if encryptErr != nil {
+		return encryptErr
+	}
+
+	// defered action to remove temporary file post-edit and post-re-encryption
+	defer os.Remove(tempFile.Name())
+
+	return nil
+}
+

--- a/command/vault/edit_profile.go
+++ b/command/vault/edit_profile.go
@@ -25,7 +25,7 @@ func EditProfile(c *cli.Context) error {
 	if _, err := os.Stat(filePath); err == nil {
 		backup = true
 
-		b, err := getProfileConfig()
+		b, err := GetProfileConfig()
 		if err != nil {
 			return err
 		}
@@ -51,6 +51,9 @@ func EditProfile(c *cli.Context) error {
 
 	// edit the file
 	editCmd := exec.Command(editor, flags...)
+	editCmd.Stdin  = os.Stdin
+	editCmd.Stdout = os.Stdout
+	editCmd.Stderr = os.Stderr
 	editErr := editCmd.Run()
 	if editErr != nil {
 		return editErr

--- a/command/vault/helper/secret_deleter.go
+++ b/command/vault/helper/secret_deleter.go
@@ -1,0 +1,45 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/vault/api"
+	"github.com/seatgeek/hashi-helper/config"
+)
+
+// SecretDeleter ...
+type SecretDeleter struct {
+	client *api.Client
+}
+
+// DeleteSecret ...
+func (w SecretDeleter) DeleteSecret(secret *config.Secret, env string) error {
+	var path string
+
+	// @TODO Make a dedicated type for writing non-secrets !
+	if strings.HasPrefix(secret.Path, "/") {
+		path = strings.TrimLeft(secret.Path, "/")
+	} else if secret.Application != nil {
+		path = fmt.Sprintf("secret/%s/%s/%s", env, secret.Application.Name, secret.Path)
+	} else {
+		path = fmt.Sprintf("secret/%s", secret.Path)
+	}
+
+	log.Warnf("Deleting secret: %s", path)
+
+	_, err := w.getClient().Logical().Delete(path)
+	return err
+}
+
+func (w SecretDeleter) getClient() *api.Client {
+	if w.client == nil {
+		client, err := api.NewClient(nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w.client = client
+	}
+	return w.client
+}

--- a/command/vault/helper/secret_writer.go
+++ b/command/vault/helper/secret_writer.go
@@ -17,14 +17,14 @@ type SecretWriter struct {
 }
 
 // WriteSecret ...
-func (w SecretWriter) WriteSecret(secret *config.Secret) error {
+func (w SecretWriter) WriteSecret(secret *config.Secret, env string) error {
 	var path string
 
 	// @TODO Make a dedicated type for writing non-secrets !
 	if strings.HasPrefix(secret.Path, "/") {
 		path = strings.TrimLeft(secret.Path, "/")
 	} else if secret.Application != nil {
-		path = fmt.Sprintf("secret/%s/%s", secret.Application.Name, secret.Path)
+		path = fmt.Sprintf("secret/%s/%s/%s", env, secret.Application.Name, secret.Path)
 	} else {
 		path = fmt.Sprintf("secret/%s", secret.Path)
 	}

--- a/command/vault/secrets_delete.go
+++ b/command/vault/secrets_delete.go
@@ -1,0 +1,75 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"bufio"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/seatgeek/hashi-helper/command/vault/helper"
+	"github.com/seatgeek/hashi-helper/config"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+// SecretsDelete ...
+func SecretsDelete(c *cli.Context) error {
+	config, err := config.NewConfigFromCLI(c)
+	if err != nil {
+		return err
+	}
+
+	return SecretsDeleteWithConfig(c, config)
+}
+
+// SecretsDeleteWithConfig ...
+func SecretsDeleteWithConfig(c *cli.Context, config *config.Config) error {
+	env := c.GlobalString("environment")
+	if env == "" {
+		return fmt.Errorf("Secret deleter requires a environment value (--environment or ENV[ENVIRONMENT])")
+	}
+
+	if !config.Environments.Contains(env) {
+		return fmt.Errorf("Could not find any environment with name %s in configuration", env)
+	}
+
+	engine := helper.SecretDeleter{}
+	for _, secret := range config.VaultSecrets {
+		// optionally verify each delete
+		do_delete := true
+		if !c.Bool("skip-confirm") {
+			log.Warnf("About to delete remote secret: secret/%s/%s/%s", env, secret.Application.Name, secret.Path)
+			do_delete = confirmDelete("Continue?", 3)
+		}
+
+		if do_delete {
+			err := engine.DeleteSecret(secret, env)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			fmt.Printf("           Skipping ...\n")
+		}
+	}
+
+	return nil
+}
+
+func confirmDelete(s string, tries int) bool {
+	r := bufio.NewReader(os.Stdin)
+	for ; tries > 0; tries-- {
+		fmt.Printf("           %s [y/n]: ", s)
+		res, err := r.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Empty input (i.e. "\n")
+		if len(res) < 2 {
+			continue
+		}
+		return strings.ToLower(strings.TrimSpace(res))[0] == 'y'
+	}
+
+	return false
+}

--- a/command/vault/secrets_import.go
+++ b/command/vault/secrets_import.go
@@ -79,14 +79,14 @@ func SecretsImport(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			log.Infof("Wrote file: %s", file)
+			log.Infof("Wrote unencrypted file: %s", file)
 
 			output, err := helper.FormatHclFile(file)
 			if err != nil {
 				return err
 			}
 
-			log.Infof("Formatted file: %s (%s)", file, output.String())
+			log.Infof("Formatted unencrypted file: %s (%s)", file, output.String())
 		}
 	}
 

--- a/command/vault/secrets_list.go
+++ b/command/vault/secrets_list.go
@@ -10,7 +10,7 @@ import (
 
 // SecretsList ...
 func SecretsList(c *cli.Context) error {
-	if c.GlobalBool("remote") {
+	if c.Bool("remote") {
 		return secretListRemote(c)
 	}
 

--- a/command/vault/secrets_pull.go
+++ b/command/vault/secrets_pull.go
@@ -95,14 +95,14 @@ func SecretsPull(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			log.Infof("Wrote file: %s", file)
+			log.Infof("Wrote unencrypted file: %s", file)
 
 			output, err := helper.FormatHclFile(file)
 			if err != nil {
 				return err
 			}
 
-			log.Infof("Formatted file: %s (%s)", file, output.String())
+			log.Infof("Formatted unencrypted file: %s (%s)", file, output.String())
 		}
 	}
 

--- a/command/vault/secrets_push.go
+++ b/command/vault/secrets_push.go
@@ -32,7 +32,7 @@ func SecretsPushWithConfig(c *cli.Context, config *config.Config) error {
 
 	engine := helper.SecretWriter{}
 	for _, secret := range config.VaultSecrets {
-		err := engine.WriteSecret(secret)
+		err := engine.WriteSecret(secret, env)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/command/vault/use_profile.go
+++ b/command/vault/use_profile.go
@@ -28,7 +28,7 @@ func UseProfile(c *cli.Context) error {
 	}
 
 	var profiles profiles
-	dat, err := getProfileConfig()
+	dat, err := GetProfileConfig()
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func UseProfile(c *cli.Context) error {
 	return nil
 }
 
-func getProfileConfig() ([]byte, error) {
+func GetProfileConfig() ([]byte, error) {
 	cmd := exec.Command("keybase", "pgp", "decrypt", "--infile", getProfileFile())
 
 	var stdout bytes.Buffer
@@ -56,7 +56,7 @@ func getProfileConfig() ([]byte, error) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	fmt.Fprintf(os.Stderr, "# Starting keybase decrypt of %s\n", getProfileFile())
+	fmt.Fprintf(os.Stderr, "\n# Starting keybase decrypt of %s\n\n", getProfileFile())
 	err := cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to run keybase gpg decrypt: %s - %s", err, stderr.String())
@@ -66,9 +66,9 @@ func getProfileConfig() ([]byte, error) {
 }
 
 func getProfileFile() string {
-	path := os.Getenv("VAULT_PROFILE_FILE")
+	path := os.Getenv("HASHIHELPER_CONFIG_FILE")
 	if path == "" {
-		path = os.Getenv("HOME") + "/.vault_profiles.pgp"
+		path = os.Getenv("HOME") + "/.hashi-helper-config.pgp"
 	}
 	return path
 }

--- a/command/vault/use_profile.go
+++ b/command/vault/use_profile.go
@@ -68,7 +68,7 @@ func GetProfileConfig() ([]byte, error) {
 func getProfileFile() string {
 	path := os.Getenv("HASHIHELPER_CONFIG_FILE")
 	if path == "" {
-		path = os.Getenv("HOME") + "/.hashi-helper-config.pgp"
+		path = os.Getenv("HOME") + "/.hashi-helper-config.yml.pgp"
 	}
 	return path
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,3 +8,6 @@ var TargetEnvironment string
 
 // TargetApplication ...
 var TargetApplication string
+
+// WarnUnencrypted ...
+var WarnUnencrypted bool

--- a/config/type_config.go
+++ b/config/type_config.go
@@ -67,7 +67,7 @@ func (c *Config) ScanDirectory(directory string) error {
 
 	var result error
 	for _, fi := range fi {
-		if fi.Mode().IsRegular() && strings.HasSuffix(fi.Name(), ".hcl") {
+		if fi.Mode().IsRegular() && (strings.HasSuffix(fi.Name(), ".hcl") || strings.HasSuffix(fi.Name(), ".pgp") ) {
 			if err := c.AddFile(directory + "/" + fi.Name()); err != nil {
 				result = multierror.Append(result, fmt.Errorf("[%s] %s", directory+"/"+fi.Name(), err))
 			}

--- a/config/type_config.go
+++ b/config/type_config.go
@@ -121,6 +121,9 @@ func (c *Config) AddFile(file string) error {
 
 	} else {
 		// unencrypted files
+    if WarnUnencrypted == true {
+      log.Warnf("Found unencrypted file: %s", file)
+    }
 		log.Debugf("Parsing file %s", file)
 		configContent = string(configContentRaw)
 		if err != nil {

--- a/config/type_config.go
+++ b/config/type_config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+  "bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 
 	"strings"
 
@@ -89,15 +91,45 @@ func (c *Config) ScanDirectory(directory string) error {
 
 // AddFile to the config struct
 func (c *Config) AddFile(file string) error {
-	log.Debugf("Parsing file %s", file)
 
-	configContent, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
+  var encryptedHcl bool = false
+	var configContent string = ""
+	configContentRaw, err := ioutil.ReadFile(file)
+
+	// look for file contents indicating an encrypted payload
+	if strings.Contains(string(configContentRaw), "-----BEGIN PGP MESSAGE-----") {
+		encryptedHcl = true
+	}
+
+	if encryptedHcl == true {
+		// files encrypted with Keybase pgp (similar to Vault profiles file)
+		log.Debugf("Decrypting file %s", file)
+		cmd := exec.Command("keybase", "pgp", "decrypt", "--infile", file)
+
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("Failed to run keybase gpg decrypt: %s - %s", err, stderr.String())
+		}
+
+		configContent = string(stdout.Bytes())
+
+	} else {
+		// unencrypted files
+		log.Debugf("Parsing file %s", file)
+		configContent = string(configContentRaw)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Parse into HCL AST
-	root, hclErr := hcl.Parse(string(configContent))
+	root, hclErr := hcl.Parse(configContent)
 	if hclErr != nil {
 		return fmt.Errorf("Could not parse file %s: %s", file, hclErr)
 	}

--- a/main.go
+++ b/main.go
@@ -57,6 +57,12 @@ func main() {
 			EnvVar:      "APPLICATION",
 			Destination: &config.TargetApplication,
 		},
+		cli.BoolFlag{
+		  Name:        "warn-unencrypted",
+		  Usage:       "Issue a warning if unencrypted HCL files are discovered",
+		  EnvVar:      "WARN_UNENCRYPTED",
+		  Destination: &config.WarnUnencrypted,
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "vault-manager"
-	app.Usage = "easily restore / snapshot your secrets"
+	app.Name = "hashi-helper"
+	app.Usage = "Manage cleartext and encrypted secrets, configuration, and more for Vault and Consul."
 	app.Version = "0.1"
 
 	app.Flags = []cli.Flag{

--- a/main.go
+++ b/main.go
@@ -65,10 +65,10 @@ func main() {
 		  Destination: &config.WarnUnencrypted,
 		},
 		cli.BoolFlag{
-			Name:        "use-keybase-team",
-			Usage:       "Use the keybase team name in config file to re-sign encrypted files post-edit",
-			EnvVar:      "USE_KEYBASE_TEAM",
-			Destination: &command.UseKeybaseTeam,
+			Name:        "no-keybase-team",
+			Usage:       "Do not use the keybase team name in config file (if specified) to re-sign encrypted files post-edit",
+			EnvVar:      "NO_KEYBASE_TEAM",
+			Destination: &command.NoKeybaseTeam,
 		},
 	}
 	app.Commands = []cli.Command{
@@ -157,9 +157,22 @@ func main() {
 		},
 		{
 			Name:  "vault-push-secrets",
-			Usage: "Write local secrets to remote Vault instance",
+			Usage: "Write local secrets to remote Vault",
 			Action: func(c *cli.Context) error {
 				return vaultCommand.SecretsPush(c)
+			},
+		},
+		{
+			Name:  "vault-delete-secrets",
+			Usage: "Delete remote secrets from Vault, leaves local secrets unchanged",
+			Action: func(c *cli.Context) error {
+				return vaultCommand.SecretsDelete(c)
+			},
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:   "skip-confirm",
+					Usage:  "Do NOT ask for confirmation at each remote Vault prefix delete",
+				},
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	consulCommand "github.com/seatgeek/hashi-helper/command/consul"
 	vaultCommand "github.com/seatgeek/hashi-helper/command/vault"
 	"github.com/seatgeek/hashi-helper/config"
+	"github.com/seatgeek/hashi-helper/command"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -63,13 +64,26 @@ func main() {
 		  EnvVar:      "WARN_UNENCRYPTED",
 		  Destination: &config.WarnUnencrypted,
 		},
+		cli.BoolFlag{
+			Name:        "use-keybase-team",
+			Usage:       "Use the keybase team name in config file to re-sign encrypted files post-edit",
+			EnvVar:      "USE_KEYBASE_TEAM",
+			Destination: &command.UseKeybaseTeam,
+		},
 	}
 	app.Commands = []cli.Command{
 		{
 			Name:  "push-all",
-			Usage: "push all consul and vault settings",
+			Usage: "Push all consul and vault settings",
 			Action: func(c *cli.Context) error {
 				return allCommand.PushAll(c)
+			},
+		},
+		{
+			Name:  "edit-file",
+			Usage: "Edit a Keybase PGP-encrypted file (config file or otherwise)",
+			Action: func(c *cli.Context) error {
+				return allCommand.EditEncryptedFile(c)
 			},
 		},
 		{


### PR DESCRIPTION
- Enable using Keybase with one or more PGP keys to decrypt and encrypt arbitrary files.
- Enable editing arbitrary files.
- Enable processing both HCL (clear text) and PGP (encrypted) files automatically.
- Enable remote `vault-list-secrets`.
- Add `environment` prefix when writing secrets.
- Enable remote secrets deletion.