### PR TITLE
Fix panic on interface {} being nil

### DIFF
--- a/command/vault/find_token.go
+++ b/command/vault/find_token.go
@@ -82,11 +82,11 @@ func FindToken(c *cli.Context) error {
 				log.Infof("  explicit_max_ttl   : %s", token.Data["explicit_max_ttl"])
 				log.Infof("  num_uses           : %s", token.Data["num_uses"])
 
-				if meta, ok := token.Data["meta"]; ok {
-					for k, v := range meta.(map[string]interface{}) {
-						log.Infof("  meta[%s] %s: %v", k, strings.Repeat(" ", max(0, 12-len(k))), v)
+				if token.Data["meta"] != nil {
+						for k, v := range token.Data["meta"].(map[string]interface{}) {
+							log.Infof("  meta[%s] %s: %v", k, strings.Repeat(" ", max(0, 12-len(k))), v)
+						}
 					}
-				}
 
 				log.Info("")
 


### PR DESCRIPTION
Resolves the following panic:

```
hashi-helper vault-find-token --filter-policy root
INFO[0000] Found 6 possible tokens, beging scanning each ...
INFO[0000]
INFO[0000] Found token: root
INFO[0000]   policies           : [root]
INFO[0000]   orphan             : true
INFO[0000]   renewable          : %!t(<nil>)
INFO[0000]   path               : auth/token/root
INFO[0000]   creation_time      : 1532514375
INFO[0000]   ttl                : 0
INFO[0000]   creation_ttl       : 0
INFO[0000]   explicit_max_ttl   : 0
INFO[0000]   num_uses           : 0
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 76 [running]:
github.com/seatgeek/hashi-helper/command/vault.FindToken.func3(0xc0004e2540, 0xc0000ecdc0, 0xc0004d0038, 0xc00037e6c0)
        /Users/mlee/go/src/github.com/seatgeek/hashi-helper/command/vault/find_token.go:86 +0xa9a
created by github.com/seatgeek/hashi-helper/command/vault.FindToken
        /Users/mlee/go/src/github.com/seatgeek/hashi-helper/command/vault/find_token.go:70 +0x3ae
```