### PR TITLE
Print accessor with vault-find-token

### DIFF
--- a/command/vault/find_token.go
+++ b/command/vault/find_token.go
@@ -81,6 +81,7 @@ func FindToken(c *cli.Context) error {
 				log.Infof("  creation_ttl       : %s", token.Data["creation_ttl"])
 				log.Infof("  explicit_max_ttl   : %s", token.Data["explicit_max_ttl"])
 				log.Infof("  num_uses           : %s", token.Data["num_uses"])
+				log.Infof("  accessor           : %s", token.Data["accessor"])
 
 				if meta, ok := token.Data["meta"]; ok {
 					for k, v := range meta.(map[string]interface{}) {


### PR DESCRIPTION
Useful for manually revoking the token later or passing to someone else with permission to do so.